### PR TITLE
[고도화] Swagger UI 로 API 문서화하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.0'
+	implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.14'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -33,6 +36,7 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+	annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행됨
이 때 Spring Data Rest 가 자동으로 만들어 준 api를
스웨거에 노출시키기 위해 추가 의존성을 사용함

This closes #96 